### PR TITLE
Add AGENTS.md and CLAUDE.md for AI agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AI Agent Instructions
+
+## Important: This is a Generated SDK
+
+This SDK is **auto-generated** by [Stainless](https://www.stainless.com/) from an OpenAPI specification. Do not manually edit generated files—your changes will be overwritten on the next generation.
+
+## What You Should NOT Do
+
+- Do not modify files outside of the safe directories listed below
+- Do not refactor, reorganize, or "improve" generated code
+- Do not add new API methods or modify existing ones directly
+- Do not update type definitions for API responses/requests
+
+## Safe Directories (Not Overwritten by Generator)
+
+The following directories are preserved between generations and can be safely edited:
+
+- `src/lib/` - Custom library code
+- `examples/` - Example usage code
+
+## If Changes Are Needed
+
+If the SDK needs changes (new endpoints, bug fixes, type corrections):
+
+1. Changes should be made to the **OpenAPI specification** or **Stainless configuration**, not this repository directly
+2. The SDK will be regenerated with the updates
+3. See the [Stainless documentation](https://www.stainless.com/docs/) for how SDK generation works
+
+## Contributing
+
+For information on running tests, linting, and local development, see [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## Resources
+
+- [Stainless Documentation](https://www.stainless.com/docs/)
+- [Stainless SDK Configuration Guide](https://www.stainless.com/docs/guides/configure/)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+Refer to @AGENTS.md for instructions.


### PR DESCRIPTION
## Summary
- Add AGENTS.md and CLAUDE.md files to inform AI agents that this SDK is auto-generated by Stainless
- Documents which directories are safe to edit (`src/lib/`, `examples/`)
- Links to Stainless documentation for understanding SDK generation

## Test plan
- [x] Verify files are created with correct content
- [x] Verify links to Stainless docs are valid

Resolves: GUM-187

🤖 Generated with [Claude Code](https://claude.com/claude-code)